### PR TITLE
support gen title for conversation; add authorization config to avoid…

### DIFF
--- a/chat.py
+++ b/chat.py
@@ -1,0 +1,60 @@
+'''
+Author: keysaim.hbp
+Date: Fri May 26 2023
+'''
+
+import sys
+import loguru
+
+from utils.chatgpt import ChatGPT
+from config.chatgpt_config import ChatGPTConfig
+
+logger = loguru.logger
+logger.remove()
+logger.add(sys.stderr, level="INFO")
+# logger.add(level="ERROR", sink="logs/chatgpt_connection_test.log")
+
+
+if __name__ == "__main__":
+    chatgpt_config = ChatGPTConfig()
+    # 1. test the connection for chatgpt cookie
+    print("#### Test connection for chatgpt cookie")
+    try:
+        # chatgpt_config.model = "gpt-3.5-turbo"
+        chatgpt = ChatGPT(chatgpt_config)
+        logger.info(f'authorization: {chatgpt.headers["authorization"]}')
+        conversations = chatgpt.get_conversation_history()
+        logger.info(conversations)
+        msg = '你现在是一个儿童剧老师，请推荐几个适合儿童表演的成语故事'
+        (text, cid) = chatgpt.send_new_message(msg)
+        print(text)
+        print(cid)
+        if not cid:
+            raise "new conversation failed"
+        cv = chatgpt.get_cached_conversation(cid)
+        logger.info(cv)
+    except Exception as e:
+        logger.info(f"exception, {e}")
+        print(e)
+
+    # def moderate_conversation(self, conversation_id: str, lastMsg: str, lastMsgId: str):
+    #     # moderate conversation with its uuid
+    #     if not conversation_id:
+    #         return
+    #     url = "https://chat.openai.com/backend-api/moderations"
+    #     data = {
+    #         "conversation_id": conversation_id,
+    #         "input": lastMsg,
+    #         "message_id": lastMsgId,
+    #         "model": "text-moderation-playground",
+    #     }
+    #     r = requests.post(url, headers=self.headers, json=data, proxies=self.proxies)
+
+    #     if r.status_code != 200:
+    #         logger.error(r)
+    #         return False
+
+    #     result = r.json()
+    #     logger.info(f"moderate conversation {conversation_id}, result: {result}")
+    #     return True
+    

--- a/config/chatgpt_config_sample.py
+++ b/config/chatgpt_config_sample.py
@@ -13,6 +13,8 @@ class ChatGPTConfig:
     userAgent: str = "<your user agent>"
     # set cookie below
     cookie: str = "<your cookie>"
+    # set authorization, like "Bearer xxxxxx"
+    authorization: str = None
 
     error_wait_time: float = 20
     is_debugging: bool = False

--- a/utils/chatgpt.py
+++ b/utils/chatgpt.py
@@ -47,6 +47,7 @@ class Message:
 
 @dataclasses.dataclass
 class Conversation:
+    title: str = None
     conversation_id: str = None
     message_list: List[Message] = dataclasses.field(default_factory=list)
 
@@ -98,7 +99,10 @@ class ChatGPT:
             "Cookie": self.config.cookie,
             "User-Agent": self.config.userAgent,
         }
-        self.headers["authorization"] = self.get_authorization()
+        if config.authorization:
+            self.headers["authorization"] = config.authorization
+        else:
+            self.headers["authorization"] = self.get_authorization()
 
     def refresh(self) -> str:
         # a workaround that refreshes the cookie from time to time with the configuration txt file.
@@ -150,7 +154,7 @@ class ChatGPT:
                     last_line = decoded_line
         return json.loads(last_line[5:])
 
-    def send_new_message(self, message, model=None):
+    def send_new_message(self, message, model=None, gen_title=False):
         if model is None:
             model = self.model
         # 发送新会话窗口消息，返回会话id
@@ -186,6 +190,7 @@ class ChatGPT:
         # parsing result
         result = self._parse_message_raw_output(r)
         text = "\n".join(result["message"]["content"]["parts"])
+        rsp_message_id = result["message"]["id"]
         conversation_id = result["conversation_id"]
         answer_id = result["message"]["id"]
 
@@ -198,7 +203,12 @@ class ChatGPT:
         conversation.conversation_id = conversation_id
         conversation.message_list.append(message)
 
+        if gen_title:
+            title = self.gen_conversation_title(conversation_id, rsp_message_id)
+            conversation.title = title
+
         self.conversation_dict[conversation_id] = conversation
+
         return text, conversation_id
 
     def send_message(self, message, conversation_id):
@@ -281,6 +291,27 @@ class ChatGPT:
         else:
             logger.error("Failed to retrieve history")
             return None
+    
+    def get_cached_conversation(self, conversation_id: str) -> Conversation:
+        return self.conversation_dict.get(conversation_id)
+    
+    def gen_conversation_title(self, conversation_id: str, rsp_message_id: str):
+        # gen conversation title
+        if not conversation_id:
+            return
+        url = f"https://chat.openai.com/backend-api/conversation/gen_title/{conversation_id}"
+        data = {
+            "message_id": rsp_message_id,
+        }
+        r = requests.post(url, headers=self.headers, json=data, proxies=self.proxies)
+
+        if r.status_code != 200:
+            return None
+
+        title = r.json()["title"]
+
+        logger.info(f"update conversation {conversation_id} title to {title}")
+        return title
 
     def delete_conversation(self, conversation_id=None):
         # delete conversation with its uuid


### PR DESCRIPTION
support gen title for conversation; add authorization config to avoid Max retries exceeded with url: /api/auth/session when debugging.

In this PR, about two issues:
* I found every time I send new message, it created new conversation without title, which is really not confortable to list all the conversations. So I add the gen title request for it.
* When I am debugging locally, I always met the error like: 
```Max retries exceeded with url: /api/auth/session (Caused by SSLError(SSLEOFError(8, 'EOF occurred in violation of protocol (_ssl.c:992)')))```. 
I guess it may be caused by that I restarted frequently when I debug the program, and each time when the program started, it would call /api/auth/session which hit the limit of ChatGPT. So I add the authorization to the config to avoid this case.