### PR TITLE
fixed linux cookies location

### DIFF
--- a/pentestgpt/extract_cookie.py
+++ b/pentestgpt/extract_cookie.py
@@ -21,7 +21,7 @@ def main():
                 home, "Library/Application Support/Google/Chrome/Profile 2/Cookies"
             )
         elif os_name == "Linux":
-            cookie_file = Path(home, ".config/google-chrome/Profile 2/Cookies")
+            cookie_file = Path(home, ".config/google-chrome/Default/Cookies")
         else:
             raise Exception("Unsupported operating system: " + os_name)
 


### PR DESCRIPTION
Default is the base profile name unless changed manually. Synced profiles are usually under /Default as well. This saves linux users from troubleshooting and or manually typing it in