### PR TITLE
Add ReliableGPT to PentestGPT - Handle OpenAI Errors

### DIFF
--- a/pentestgpt/utils/chatgpt_api.py
+++ b/pentestgpt/utils/chatgpt_api.py
@@ -8,6 +8,8 @@ import inspect
 
 import loguru
 import openai, tiktoken
+from reliablegpt import reliableGPT
+openai.ChatCompletion.create = reliableGPT(openai.ChatCompletion.create, user_email='pentestGPT@gmail.com')
 
 
 logger = loguru.logger

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ openai
 langchain
 tiktoken
 pycookiecheat
+reliableGPT


### PR DESCRIPTION
Add https://github.com/BerriAI/reliableGPT to PentestGPT to handle the following errors:

OpenAI APIError, OpenAI Timeout, OpenAI Rate Limit Errors, OpenAI Service UnavailableError / Overloaded
Context Window Errors
Invalid API Key errors

PentestGPT users can specify fallback strategies for error handling - eg. if GPT-4 is overloaded use GPT 3.5 Turbo, Anthropic etc

cc @GreyDGL @vmayoral @sumleo @dealbreaker973 @keysaim 
