### PR TITLE
Added a feature that allows you to specify the log output directory using -- logDir

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@
   - **A**: AutoGPT is not designed for pentest. It may perform malicious operations. Due to this consideration, we design PentestGPT in an interactive mode. Of course, our end goal is an automated pentest solution.
 
     
+
 <!-- GETTING STARTED -->
 ## Getting Started
 - **PentestGPT** is a penetration testing tool empowered by **ChatGPT**. 
@@ -119,7 +120,10 @@ Please watch the installation video [here](https://youtu.be/tGC5z14dE24).
       - `pentestgpt --reasoning_model=gpt-4 --useAPI`
       - `pentestgpt --reasoning_model=gpt-3.5-turbo --useAPI`
       - `pentestgpt --reasoning_model=gpt-3.5-turbo-16k --useAPI`
-
+    - `--baseUrl`  is the url where you want to use another GPT4, which are:
+      - `pentestgpt --useAPI --baseUrl https://{your own endpoint}.openai.azure.com`
+      - `pentestgpt --useAPI --baseUrl https://openai.api2d.net/v1`
+    - `--logDir` is the the customized log output directory. The location is a relative directory
 2. The tool works similar to *msfconsole*. Follow the guidance to perform penetration testing. 
 3. In general, PentestGPT intakes commands similar to chatGPT. There are several basic commands.
    1. The commands are: 
@@ -204,4 +208,4 @@ Distributed under the MIT License. See `LICENSE.txt` for more information.
 [Bootstrap.com]: https://img.shields.io/badge/Bootstrap-563D7C?style=for-the-badge&logo=bootstrap&logoColor=white
 [Bootstrap-url]: https://getbootstrap.com
 [JQuery.com]: https://img.shields.io/badge/jQuery-0769AD?style=for-the-badge&logo=jquery&logoColor=white
-[JQuery-url]: https://jquery.com 
+[JQuery-url]: https://jquery.com

--- a/pentestgpt/config/chatgpt_config.py
+++ b/pentestgpt/config/chatgpt_config.py
@@ -13,6 +13,8 @@ class ChatGPTConfig:
 
     api_base: str = "https://api.openai.com/v1"
 
+    log_dir: str = "logs"
+
     # set up the openai key
     openai_key = os.getenv("OPENAI_KEY", None)
     # set the user-agent below

--- a/pentestgpt/main.py
+++ b/pentestgpt/main.py
@@ -4,14 +4,13 @@ import argparse
 
 from pentestgpt.utils.pentest_gpt import pentestGPT
 
-logger = loguru.logger
-
 
 def main():
     """main function"""
     parser = argparse.ArgumentParser(description="PentestGPT")
     parser.add_argument("--reasoning_model", type=str, default="gpt-4")
     parser.add_argument("--useAPI", action="store_true", default=False)
+    parser.add_argument("--logDir", type=str, default="logs")
     parser.add_argument(
         "--baseUrl",
         type=str,
@@ -21,7 +20,10 @@ def main():
     args = parser.parse_args()
 
     pentestGPTHandler = pentestGPT(
-        reasoning_model=args.reasoning_model, useAPI=args.useAPI, baseUrl=args.baseUrl
+        reasoning_model=args.reasoning_model, 
+        useAPI=args.useAPI, 
+        baseUrl=args.baseUrl,
+        logDir=args.logDir
     )
 
     # you may use this one if you want to use OpenAI API (without GPT-4)

--- a/pentestgpt/test_connection.py
+++ b/pentestgpt/test_connection.py
@@ -10,11 +10,17 @@ import argparse
 from rich.console import Console
 
 logger = loguru.logger
-logger.add(level="ERROR", sink="logs/chatgpt_connection_test.log")
 
 
 def main():
     parser = argparse.ArgumentParser(description="PentestGPTTestConnection")
+    parser.add_argument(
+        "--logDir",
+        type=str,
+        default="logs",
+        help="Log file directory for PentestGPTTestConnection",
+    )
+
     parser.add_argument(
         "--baseUrl",
         type=str,
@@ -23,10 +29,11 @@ def main():
     )
 
     args = parser.parse_args()
+    logger.add(args.logDir+"/chatgpt_connection_test.log",level="ERROR")
 
     chatgpt_config = ChatGPTConfig(api_base=args.baseUrl)
     console = Console()
-
+    
     # 1. test the connection for chatgpt cookie
     print("#### Test connection for chatgpt cookie")
     try:

--- a/pentestgpt/utils/chatgpt.py
+++ b/pentestgpt/utils/chatgpt.py
@@ -5,6 +5,7 @@ import json
 import re
 import sys
 import time
+import os
 from typing import Any, Dict, List, Tuple
 from uuid import uuid1
 
@@ -17,7 +18,7 @@ import openai
 
 logger = loguru.logger
 logger.remove()
-logger.add(level="ERROR", sink="logs/chatgpt.log")
+# logger.add(level="ERROR", sink="logs/chatgpt.log")
 
 
 # A sample ChatGPTConfig class has the following structure. All fields can be obtained from the browser's cookie.
@@ -87,6 +88,9 @@ class ChatGPT:
         self.config = config
         self.model = config.model
         self.proxies = config.proxies
+        self.log_dir = config.log_dir
+
+        logger.add(sink=os.path.join(self.log_dir, "chatgpt.log"), level="ERROR")
         # self._puid = config._puid
         # self.cf_clearance = config.cf_clearance
         # self.session_token = config.session_token

--- a/pentestgpt/utils/chatgpt_api.py
+++ b/pentestgpt/utils/chatgpt_api.py
@@ -1,6 +1,8 @@
 import dataclasses
 import re
 import time
+import os
+
 from typing import Any, Dict, List, Tuple
 from uuid import uuid1
 from pentestgpt.config.chatgpt_config import ChatGPTConfig
@@ -12,8 +14,7 @@ import openai, tiktoken
 
 logger = loguru.logger
 logger.remove()
-logger.add(level="WARNING", sink="logs/chatgpt.log")
-
+# logger.add(level="WARNING", sink="logs/chatgpt.log")
 
 @dataclasses.dataclass
 class Message:
@@ -46,8 +47,11 @@ class ChatGPTAPI:
         openai.api_key = config.openai_key
         openai.proxy = config.proxies
         openai.api_base = config.api_base
+        self.log_dir = config.log_dir
         self.history_length = 5  # maintain 5 messages in the history. (5 chat memory)
         self.conversation_dict: Dict[str, Conversation] = {}
+
+        logger.add(sink=os.path.join(self.log_dir, "chatgpt.log"),level="WARNING")
 
     def count_token(self, messages) -> int:
         """

--- a/pentestgpt/utils/pentest_gpt.py
+++ b/pentestgpt/utils/pentest_gpt.py
@@ -22,7 +22,6 @@ import loguru
 import time, os, textwrap, json, sys, traceback
 
 logger = loguru.logger
-logger.add(sink="logs/pentest_gpt.log")
 
 
 def prompt_continuation(width, line_number, wrap_count):
@@ -49,9 +48,14 @@ class pentestGPT:
     }
 
     def __init__(
-        self, reasoning_model="gpt-4", useAPI=True, baseUrl="https://api.openai.com/v1"
-    ):
-        self.log_dir = "logs"
+        self, 
+        reasoning_model="gpt-4",
+        useAPI=True, 
+        baseUrl="https://api.openai.com/v1",
+        logDir="logs",
+    ):  
+        self.log_dir = logDir
+        logger.add(sink=os.path.join(logDir, "pentestGPT.log"))
         self.save_dir = "test_history"
         self.task_log = (
             {}
@@ -59,12 +63,12 @@ class pentestGPT:
         self.useAPI = useAPI
         self.baseUrl = baseUrl
         if useAPI is False:
-            self.chatGPTAgent = ChatGPT(ChatGPTConfig())
-            self.chatGPT4Agent = ChatGPT(ChatGPTConfig(model=reasoning_model))
+            self.chatGPTAgent = ChatGPT(ChatGPTConfig(log_dir=self.log_dir))
+            self.chatGPT4Agent = ChatGPT(ChatGPTConfig(model=reasoning_model, log_dir=self.log_dir))
         else:
-            self.chatGPTAgent = ChatGPTAPI(ChatGPTConfig())
+            self.chatGPTAgent = ChatGPTAPI(ChatGPTConfig(log_dir=self.log_dir))
             self.chatGPT4Agent = ChatGPTAPI(
-                ChatGPTConfig(model=reasoning_model, api_base=baseUrl)
+                ChatGPTConfig(model=reasoning_model, api_base=baseUrl, log_dir=self.log_dir)
             )
         self.prompts = PentestGPTPrompt
         self.console = Console()

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(os.path.join(os.path.dirname(__file__), "requirements.txt")) as f:
 
 setup(
     name="pentestgpt",
-    version="0.8.0",
+    version="0.8.1",
     description="PentestGPT, a GPT-empowered penetration testing tool",
     long_description="""
     PentestGPT is a penetration testing tool empowered by ChatGPT.


### PR DESCRIPTION
I've added a feature that allows you to customize the output directory of the log using --logDir
This feature from the issue:https://github.com/GreyDGL/PentestGPT/issues/121

Final run result:（ps:just to demonstrate the effect of customizing the log directory, I manually deleted all the error logs）
```
root@3652c99924d0:/home# pentestgpt --useAPI  --logDir lossssss
Your OPENAI_KEY is not set. Please set it in the environment variable.
Your CHATGPT_COOKIE is not set. Please set it in the environment variable.
Do you want to continue from previous session? (y/n) n
- ChatGPT Sessions Initialized.
root@3652c99924d0:/home# ls
lossssss
root@3652c99924d0:/home# cd lossssss/
root@3652c99924d0:/home/lossssss# ls
chatgpt.log  pentestGPT.log
root@3652c99924d0:/home/lossssss# cat pentestGPT.log 
2023-06-28 13:14:36.905 | ERROR    | 
root@3652c99924d0:/home/lossssss# cat chatgpt.log 
2023-06-28 13:14:36.905 | ERROR    | 
```


I hope I understood it correctly and completed the function