### PR TITLE
Fast bugfix

### DIFF
--- a/pentestgpt/utils/APIs/chatgpt_api.py
+++ b/pentestgpt/utils/APIs/chatgpt_api.py
@@ -93,7 +93,7 @@ class ChatGPTAPI(LLMAPI):
             logger.error("Token size error; will retry with compressed message ", e)
             # compress the message in two ways.
             ## 1. compress the last message
-            history[-1]["content"] = self.token_compression(history)
+            history[-1]["content"] = self._token_compression(history)
             ## 2. reduce the number of messages in the history. Minimum is 2
             if self.history_length > 2:
                 self.history_length -= 1

--- a/pentestgpt/utils/llm_api.py
+++ b/pentestgpt/utils/llm_api.py
@@ -96,7 +96,7 @@ class LLMAPI:
         -------
             compressed_message: str
         """
-        if self.config.model == "gpt-4":
+        if self.model == "gpt-4":
             token_limit = 8000
         else:
             token_limit = 14000  # leave some budget


### PR DESCRIPTION
Python version = **3.10.12**

1. Cloned repo
2. Installed package using `pip3 install -e .`
3. Setup env variable for **OPENAI_KEY**
4. `pentestgpt-connection`

First error raised: `pentestgpt/utils/APIs/chatgpt_api.py` line 96 _(More info in commit description)_
Second error raised: `pentestgpt/utils/llm_api.py` line 99 _(More info in commit description)_

The APIKEY used is activated and properly configured.
**After the fix I can use the tool correctly.**