### PR TITLE
Fix session bug

### DIFF
--- a/pentestgpt/utils/pentest_gpt.py
+++ b/pentestgpt/utils/pentest_gpt.py
@@ -611,7 +611,7 @@ class pentestGPT:
         if save_name == "":
             save_name = str(time.time())
         # 2. Save the current session
-        with open(os.path.join(self.save_dir, save_name), "w") as f:
+        with open(os.path.join(os.path.realpath(os.path.dirname(__file__)), os.pardir, os.pardir, self.save_dir, save_name), "w") as f:
             # store the three ids and task_log
             session_ids = {
                 "reasoning": self.test_reasoning_session_id,
@@ -637,7 +637,7 @@ class pentestGPT:
             "Do you want to continue from previous session?"
         ):
             # load the filenames from the save directory
-            filenames = os.listdir(self.save_dir)
+            filenames = os.listdir(os.path.join(os.path.realpath(os.path.dirname(__file__)), os.pardir, os.pardir, self.save_dir))
             if len(filenames) == 0:
                 print("No previous session found. Please start a new session.")
                 return None
@@ -664,7 +664,7 @@ class pentestGPT:
         if previous_testing_name is not None:
             # try to load the file content with json
             try:
-                with open(os.path.join(self.save_dir, previous_testing_name), "r") as f:
+                with open(os.path.join(os.path.realpath(os.path.dirname(__file__)), os.pardir, os.pardir, self.save_dir, previous_testing_name), "r") as f:
                     return json.load(f)
             except Exception as e:
                 print(


### PR DESCRIPTION
Python version = **3.10.12**

1. Cloned repo
2. Installed package using `pip3 install -e .`
3. Setup env variable for **OPENAI_KEY**
4. `pentestgpt-connection`

When using `pentestgpt` from console there is an error while:
- **saving** session after the `quit` command
- **loading** session at the start of the tool

The problem is `FileNotFoundError: [Errno 2] No such file or directory: 'test_history/<session_name>'`.