### PR TITLE
Fix start with no API KEY

### DIFF
--- a/pentestgpt/config/chatgpt_config.py
+++ b/pentestgpt/config/chatgpt_config.py
@@ -23,7 +23,9 @@ class ChatGPTConfig:
     cookie: str = os.getenv("CHATGPT_COOKIE", None)
 
     if openai_key is None:
-        print("Your OPENAI_KEY is not set. Please set it in the environment variable.")
+        print('Your OPENAI_KEY is not set. Please set it in the environment variable.\nIf you want to use chatGPT with no API, use "text-davinci-002-render-sha" in chatgpt_config.py')
+        if model != "text-davinci-002-render-sha":
+            exit(1)
     if cookie is None:
         print(
             "Your CHATGPT_COOKIE is not set. Please set it in the environment variable."

--- a/pentestgpt/config/chatgpt_config.py
+++ b/pentestgpt/config/chatgpt_config.py
@@ -25,7 +25,7 @@ class ChatGPTConfig:
     if openai_key is None:
         print('Your OPENAI_KEY is not set. Please set it in the environment variable.\nIf you want to use chatGPT with no API, use "text-davinci-002-render-sha" in chatgpt_config.py')
         if model != "text-davinci-002-render-sha":
-            exit(1)
+            sys.exit(1)
     if cookie is None:
         print(
             "Your CHATGPT_COOKIE is not set. Please set it in the environment variable."


### PR DESCRIPTION
More info in order to understand what happens when you have no API KEY.
Allowed "no API KEY" only if `model == "text-davinci-002-render-sha"`