### PR TITLE
Typos and cURL fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Please watch the installation video [here](https://youtu.be/tGC5z14dE24).
       The user can submit info about:
         * **tool**: output of the security test tool used
         * **web**: relevant content of a web page
-        * **deafult**: whatever you want, the tool will handle it
+        * **default**: whatever you want, the tool will handle it
         * **user-comments**: user comments about PentestGPT operations
 5. In the sub-task handler initiated by `more`, users can execute more commands to investigate into a specific problem:
    1. The commands are:

--- a/pentestgpt/config/chatgpt_config.py
+++ b/pentestgpt/config/chatgpt_config.py
@@ -21,6 +21,8 @@ class ChatGPTConfig:
     userAgent: str = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36"
     # set cookie below
     cookie: str = os.getenv("CHATGPT_COOKIE", None)
+    # curl command file
+    curl_file: str = os.path.join(os.path.realpath(os.path.dirname(__file__)), "chatgpt_config_curl.txt")
 
     if openai_key is None:
         print(

--- a/pentestgpt/utils/pentest_gpt.py
+++ b/pentestgpt/utils/pentest_gpt.py
@@ -151,7 +151,7 @@ class pentestGPT:
                 "Please ensure that you put the curl command into `config/chatgpt_config_curl.txt`",
             )
             input("Press Enter to continue...")
-            self.parsingAGent.refresh()
+            self.parsingAgent.refresh()
             self.reasoningAgent.refresh()
             self.console.print(
                 "Session refreshed. If you receive the same session refresh request, please refresh the ChatGPT page and paste the new curl request again.",


### PR DESCRIPTION
When running **without** API, `useAPI==False` there is no curl file in the configuration file.
With these changes you can use the cURL version of PentestGPT.
I know it is *deprecated*, but I think using a combination of cURL and API calls may be useful for [Issue #164](https://github.com/GreyDGL/PentestGPT/issues/164).

I am trying to use the right endpoint to retrieve a conversation:
* `https://chat.openai.com/backend-api/conversation/{conversation_id}`
* `https://chat.openai.com/backend-api/conversations`

@GreyDGL, do you have any suggestions?