### PR TITLE
🐛 Unable to use GPT4all with default setup

### DIFF
--- a/pentestgpt/config/chatgpt_config.py
+++ b/pentestgpt/config/chatgpt_config.py
@@ -30,8 +30,6 @@ class ChatGPTConfig:
         print(
             'Your OPENAI_KEY is not set. Please set it in the environment variable.\nIf you want to use chatGPT with no API, use "text-davinci-002-render-sha" in chatgpt_config.py'
         )
-        if model != "text-davinci-002-render-sha":
-            sys.exit(1)
     if cookie is None:
         print(
             "Your CHATGPT_COOKIE is not set. Please set it in the environment variable."

--- a/pentestgpt/utils/APIs/module_import.py
+++ b/pentestgpt/utils/APIs/module_import.py
@@ -75,7 +75,7 @@ class GPT4Turbo:
 
 @dataclasses.dataclass
 class GPT4ALLConfigClass:
-    model: str = "orca-mini-3b.ggmlv3.q4_0.bin"
+    model: str = "mistral-7b-openorca.Q4_0.gguf"
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
This PR fixes the issue of not being able to use the `--reasoning_model=gpt4all` and `--parsing_model=gpt4all` options without changing the source code. Mainly caused by two problems.

- The program exits with status code 1 when the `OPENAI_KEY` is not set.
- The default GPT4all model is outdated and no longer available through GPT4all

These issues have been fixed by the following methods:
- The force exit has been removed
- The default GPT4all model has been changed to `mistral-7b-openorca.Q4_0.gguf`