### PR TITLE
Fix a tiny typo in `main.py`

### DIFF
--- a/pentestgpt/main.py
+++ b/pentestgpt/main.py
@@ -22,14 +22,14 @@ def main():
         "--reasoning_model",
         type=str,
         default="gpt-4",
-        help="parsing models deal with the structural and grammatical aspects of language, choose 'gpt-4' or 'gpt-3.5-turbo-16k'",
+        help="reasoning models are responsible for higher-level cognitive tasks, choose 'gpt-4' or 'gpt-3.5-turbo-16k'",
     )
     # 2. Parsing Model
     parser.add_argument(
         "--parsing_model",
         type=str,
         default="gpt-3.5-turbo-16k",
-        help="reasoning models are responsible for higher-level cognitive tasks, choose 'gpt-4' or 'gpt-3.5-turbo-16k'",
+        help="parsing models deal with the structural and grammatical aspects of language, choose 'gpt-4' or 'gpt-3.5-turbo-16k'",
     )
 
     # 3. use langfuse default logging


### PR DESCRIPTION
To fix a tiny typo in `main.py`.