### PR TITLE
Add support for customizing API Base URL using environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@
 ## Quick Start
 1. Create a virtual environment if necessary. (`virtualenv -p python3 venv`, `source venv/bin/activate`)
 2. Install the project with `pip3 install git+https://github.com/GreyDGL/PentestGPT`
-3. **Ensure that you have link a payment method to your OpenAI account.** Export your API key with `export OPENAI_KEY='<your key here>'`
+3. **Ensure that you have link a payment method to your OpenAI account.** Export your API key with `export OPENAI_KEY='<your key here>'`,export API base with `export OPENAI_BASEURL='https://api.xxxx.xxx/v1'`if you need.
 4. Test the connection with `pentestgpt-connection`
 5. For Kali Users: use `tmux` as terminal environment. You can do so by simply run `tmux` in the native terminal.
 6. To start: `pentestgpt --logging`
@@ -101,6 +101,7 @@ PentestGPT is tested under `Python 3.10`. Other Python3 versions should work but
 2. To use OpenAI API
    - **Ensure that you have link a payment method to your OpenAI account.**
    - export your API key with `export OPENAI_KEY='<your key here>'`
+   - export API base with `export OPENAI_BASEURL='https://api.xxxx.xxx/v1'`if you need.
    - Test the connection with `pentestgpt-connection`
 3. To verify that the connection is configured properly, you may run `pentestgpt-connection`. After a while, you should see some sample conversation with ChatGPT.
    - A sample output is below

--- a/pentestgpt/config/chatgpt_config.py
+++ b/pentestgpt/config/chatgpt_config.py
@@ -14,7 +14,7 @@ class ChatGPTConfig:
 
     #api_base: str = "https://api.openai.com/v1"
     #set up the openai api base, default:"https://api.openai.com/v1"
-    api_base = os.getenv("OPENAI_BASEURL", "https://api.openai.com/v1")
+    api_base: str = os.getenv("OPENAI_BASEURL", "https://api.openai.com/v1")
 
     log_dir: str = "logs"
 

--- a/pentestgpt/config/chatgpt_config.py
+++ b/pentestgpt/config/chatgpt_config.py
@@ -12,7 +12,9 @@ class ChatGPTConfig:
     # model: str = "text-davinci-002-render-sha"
     model: str = "gpt-4-browsing"
 
-    api_base: str = "https://api.openai.com/v1"
+    #api_base: str = "https://api.openai.com/v1"
+    #set up the openai api base, default:"https://api.openai.com/v1"
+    api_base = os.getenv("OPENAI_BASEURL", "https://api.openai.com/v1")
 
     log_dir: str = "logs"
 

--- a/pentestgpt/test_connection.py
+++ b/pentestgpt/test_connection.py
@@ -30,7 +30,7 @@ def main():
     parser.add_argument(
         "--baseUrl",
         type=str,
-        default="https://api.openai.com/v1",
+        default=ChatGPTConfig.api_base,
         help="Base URL for OpenAI API,default: https://api.openai.com/v1",
     )
 

--- a/pentestgpt/test_connection.py
+++ b/pentestgpt/test_connection.py
@@ -30,7 +30,7 @@ def main():
     parser.add_argument(
         "--baseUrl",
         type=str,
-        default=ChatGPTConfig.api_base,
+        default=ChatGPTConfig().api_base,
         help="Base URL for OpenAI API,default: https://api.openai.com/v1",
     )
 


### PR DESCRIPTION
Key Changes:
- Configuration Option: Added a new configuration option in the environment variables to specify a custom API base URL. This option is optional and defaults to OpenAI API base URL if not set.
- Documentation Update: Updated the project's documentation to guide users on how to utilize this new feature.
- If the `--baseURL` parameter is not set in `test_connection`, the base URL set in the environment variable will be used first.