### PR TITLE
OPENAI_BASEURL environment not working fixes

### DIFF
--- a/pentestgpt/utils/APIs/module_import.py
+++ b/pentestgpt/utils/APIs/module_import.py
@@ -40,7 +40,7 @@ module_mapping = {
 @dataclasses.dataclass
 class GPT4ConfigClass:
     model: str = "gpt-4"
-    api_base: str = "https://api.openai.com/v1"
+    api_base: str = os.getenv("OPENAI_BASEURL", "https://api.openai.com/v1")
     # set up the openai key
     openai_key = os.getenv("OPENAI_KEY", None)
     if openai_key is None:
@@ -52,7 +52,7 @@ class GPT4ConfigClass:
 @dataclasses.dataclass
 class GPT35Turbo16kConfigClass:
     model: str = "gpt-3.5-turbo-16k"
-    api_base: str = "https://api.openai.com/v1"
+    api_base: str = os.getenv("OPENAI_BASEURL", "https://api.openai.com/v1")
     # set up the openai key
     openai_key = os.getenv("OPENAI_KEY", None)
     if openai_key is None:
@@ -64,7 +64,7 @@ class GPT35Turbo16kConfigClass:
 @dataclasses.dataclass
 class GPT4Turbo:
     model: str = "gpt-4-1106-preview"
-    api_base: str = "https://api.openai.com/v1"
+    api_base: str = os.getenv("OPENAI_BASEURL", "https://api.openai.com/v1")
     # set up the openai key
     openai_key = os.getenv("OPENAI_KEY", None)
     if openai_key is None:


### PR DESCRIPTION
When `dynamic_import` modules, the `api_base` is not loaded from environment `OPENAI_BASEURL`.