### PR TITLE
fix: `pentestgpt-connection` exits with exit code `0` on success

### DIFF
--- a/pentestgpt/test_connection.py
+++ b/pentestgpt/test_connection.py
@@ -89,7 +89,7 @@ def main():
         )
         print("The error is below:", e)
 
-    return can_connect
+    return 0 if can_connect else 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

```console
% export OPENAI_API_KEY='XXXXXXXX'

% ~/.pyenv/versions/3.10.16/bin/pentestgpt-connection
Your CHATGPT_COOKIE is not set. Please set it in the environment variable.
You're testing the connection for PentestGPT v"0.14.0"
#### Test connection for OpenAI api (GPT-3.5)
New conversation.XXXXXXX is created.

1. You're connected with OpenAI API. You have GPT-3.5 access. To start PentestGPT, please use <pentestgpt --reasoning_model=gpt-3.5-turbo-16k>
#### Test connection for OpenAI api (GPT-4)
New conversation.XXXXXXX is created.

1. You're connected with OpenAI API. You have GPT-4(o) access. To start PentestGPT, please use <pentestgpt --reasoning_model=gpt-4o>

% echo $?
1  # <= should be 0
```

## Solution

See the small diff 😄 